### PR TITLE
Add Python 3 Support

### DIFF
--- a/octoprint_displayprogress/__init__.py
+++ b/octoprint_displayprogress/__init__.py
@@ -65,6 +65,7 @@ class DisplayProgressPlugin(octoprint.plugin.ProgressPlugin,
 		return "[{}{}]".format(hashes, spaces)
 
 __plugin_name__ = "DisplayProgress"
+__plugin_pythoncompat__ = ">=2.7,<4"
 
 def __plugin_load__():
 	global __plugin_implementation__

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_displayprogress"
 plugin_name = "OctoPrint-DisplayProgress"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "0.1.2"
+plugin_version = "0.1.3"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module


### PR DESCRIPTION
As Python 2 has now officially reached End Of Life (https://www.python.org/doc/sunset-python-2/), and Octoprint supports Python 3 as of Release 1.4.0, all plugins are encouraged to add Python 3 compatibility, which is what I have done in this pull request.
To accomplish this, I have made the following changes:

- Added the plugin property plugin_pythoncompat = ">=2.7,<4"
- Updated the plugin version to 0.1.3

This update has being tested and confirmed to work in both Python 2.7 and 3.7 using Octoprint 1.4.0 running on Octopi 0.17.0

Cheers,
Alex.